### PR TITLE
Fixed problematic definition of undefined (by removing it)

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -2,8 +2,6 @@
 
 (provide define/memo memo-lambda define/memo* memo-lambda*)
 
-(define undefined (letrec ([x x]) x))
-
 (define (assoc/inner-eq arglist cache)
   (cond
     [(null? cache) #f]


### PR DESCRIPTION
This old memoize still defines its own undefined value. The way it defines it ensures it won't work on any version of Racket at least as recent as 6.1.

From https://docs.racket-lang.org/guide/void_undefined.html :

In previous versions of Racket (before version 6.1), referencing a local binding too early produced #<undefined>; too-early references now raise an exception, instead.
